### PR TITLE
Add note about chartContainer to pan&zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,10 +657,10 @@ let orgchart = new OrgChart(options);
       <td>data</td><td>json or string</td><td>yes</td><td></td><td>datasource usded to build out structure of orgchart. It could be a json object or a string containing the URL to which the ajax request is sent.</td>
     </tr>
     <tr>
-      <td>pan</td><td>boolean</td><td>no</td><td>false</td><td>Users could pan the orgchart by mouse drag&drop if they enable this option.</td>
+      <td>pan</td><td>boolean</td><td>no</td><td>false</td><td>Users could pan the orgchart by mouse drag&drop if they enable this option. Note: When you want to enable pan, you must set "chartContainer" option at the same time.</td>
     </tr>
     <tr>
-      <td>zoom</td><td>boolean</td><td>no</td><td>false</td><td>Users could zoomin/zoomout the orgchart by mouse wheel if they enable this option.</td>
+      <td>zoom</td><td>boolean</td><td>no</td><td>false</td><td>Users could zoomin/zoomout the orgchart by mouse wheel if they enable this option. Note: When you want to enable zoom, you must set "chartContainer" option at the same time.</td>
     </tr>
     <tr>
       <td>direction</td><td>string</td><td>no</td><td>"t2b"</td><td>The available values are t2b(implies "top to bottom", it's default value), b2t(implies "bottom to top"), l2r(implies "left to right"), r2l(implies "right to left").</td>


### PR DESCRIPTION
When you want to use pan or zoom, you need to set chartContainer:

I know that chartContianer have:
```
<td>chartContainer</td><td>string</td><td>no</td><td></td><td>selector usded to query the wrapper element of orgchart. It could be an id or an unique className. Note: when you want to enable pan&zoom option, you must set "chartContainer" option at the same time.</td>
```

However when you want to enable pan, you are not going to look for the chartContainer config. You are looking on pan config. It took us couple of hours of debugging before we have found out this from the source code. I think this note can save time others. 

Thanks